### PR TITLE
Switch from actions-rs/toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: swatinem/rust-cache@v1
-      - name: cargo-check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
 
   flake-check:
     runs-on: ubuntu-latest
@@ -84,17 +80,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@1.60.0
         with:
-          toolchain: 1.60.0
-      - run: rustup component add rustfmt
-      - name: cargo-fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
 
   doc:
@@ -126,16 +116,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: swatinem/rust-cache@v1
-      - name: cargo-test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --all-features
+      - run: cargo test --all --all-features
 
 
   clippy:
@@ -144,14 +129,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@1.60.0
         with:
-          toolchain: 1.60.0
-          override: true
+          components: clippy
       - uses: swatinem/rust-cache@v1
-      - run: rustup component add clippy
-      - name: cargo-clippy
-        run: cargo clippy --all --all-targets --all-features -- -D warnings
+      - run: cargo clippy --all --all-targets --all-features -- -D warnings
 
   outdated:
     needs: check
@@ -164,14 +147,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          override: true
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@1.60.0
       - uses: swatinem/rust-cache@v1
       - run: cargo install --locked cargo-outdated
-      - name: cargo-outdated
-        run: cargo outdated --root-deps-only --color always
+      - run: cargo outdated --root-deps-only --color always
 
   cross:
     name: cross
@@ -184,17 +164,11 @@ jobs:
           - aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.60.0
         with:
-          toolchain: 1.60.0
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - uses: swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target=${{ matrix.target }}
+      - run: cargo build --target=${{ matrix.target }}
 
   cross-test:
     name: cross-test
@@ -206,17 +180,11 @@ jobs:
           - aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.60.0
         with:
-          toolchain: 1.60.0
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - uses: swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --target=${{ matrix.target }}
+      - run: cargo test --target=${{ matrix.target }}
 
   # We need some "accummulation" job here because bors fails (timeouts) to
   # listen on matrix builds.


### PR DESCRIPTION
Because actions-rs/toolchain is unmaintained, we switch over to
dtolnay/rust-toolchain in the workflow implementation
