### PR TITLE
Add information about float size in TypeKind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,10 @@ pub enum TypeKind {
     Integer,
 
     /// Type represents a floating point value `1.0, 20.235, 3.1419`
-    Float,
+    Float {
+        /// The size of the value
+        size: u8,
+    },
 
     /// Type represents a string
     String,
@@ -194,8 +197,8 @@ impl_config_kind!(TypeKind::Integer; "Integer"; "A signed integer with 8 bits th
 impl_config_kind!(TypeKind::Integer; "Integer"; "An unsigned integer with 8 bits" => u8);
 impl_config_kind!(TypeKind::Integer; "Integer"; "An unsigned integer with 8 bits that cannot be zero" => std::num::NonZeroU8);
 
-impl_config_kind!(TypeKind::Float; "Float"; "A floating point value with 64 bits" => f64);
-impl_config_kind!(TypeKind::Float; "Float"; "A floating point value with 32 bits" => f32);
+impl_config_kind!(TypeKind::Float { size: 64 }; "Float"; "A floating point value with 64 bits" => f64);
+impl_config_kind!(TypeKind::Float { size: 32 }; "Float"; "A floating point value with 32 bits" => f32);
 
 impl_config_kind!(TypeKind::Bool; "Boolean"; "A boolean" => bool);
 impl_config_kind!(TypeKind::String; "String"; "An UTF-8 string" => String);
@@ -218,7 +221,7 @@ mod tests {
                 doc: None,
                 kind: TypeKind::Array(x),
                 ..
-            } if matches!(x.kind(), TypeKind::Float)
+            } if matches!(x.kind(), TypeKind::Float { size: 64 })
         ));
 
         let complex_config = HashMap::<String, Vec<HashMap<String, String>>>::as_type_description();
@@ -238,7 +241,7 @@ mod tests {
                 match value.kind() {
                     TypeKind::Array(arr) => {
                         match arr.kind() {
-                            TypeKind::Float => { /* good */ }
+                            TypeKind::Float { size: 64 } => { /* good */ }
                             other => panic!("Expected Float, got {:?}", other),
                         }
                     }


### PR DESCRIPTION
This patch adds the information about the float size in the TypeKind
enum, so that downstream users can use that information when using the
library.
