### PR TITLE
Run CI pipeline on all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master, staging, trying]
   pull_request:
-    branches: [master, 'release-*']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
In #19 I saw that the CI pipeline does not run always, but (IMO) it should.