### PR TITLE
Make dependabot only execute weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly


### PR DESCRIPTION
Figured that dependabot is quite high-volume on this repository, so maybe we want to reduce how often it is executed to reduce PR pressure in that regard a bit.