### PR TITLE
Tell bors to cut body after <details>

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,5 +3,7 @@ status = [
     "CI"
 ]
 
+cut_body_after = "<details>"
+
 delete_merged_branches = true
 


### PR DESCRIPTION
This way we do not get the full dependabot PR title message in the merge commit message.