### PR TITLE
Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -4,8 +4,8 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    # 01:15 every monday
-    - cron:  '15 1 * * 1'
+    # 01:15 every 1st of month
+    - cron:  '15 1 1 * *'
 
 jobs:
   lockfile:


### PR DESCRIPTION
There's not much development on the repository anymore, so make the dependency-update jobs only execute monthly.