### PR TITLE
Impl AsTypeDescription for PathBuf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ impl_config_kind!(TypeKind::String; "String"; "An IPv6 socket address" => std::n
 #[cfg(feature = "url")]
 impl_config_kind!(TypeKind::String; "String"; "An URL" => url::Url);
 
-impl_config_kind!(TypeKind::String; "String"; "A path" => std::path::PathBuf);
+impl_config_kind!(TypeKind::String; "String"; "A filesystem path" => std::path::PathBuf);
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,6 +309,8 @@ impl_config_kind!(TypeKind::String; "String"; "An IPv6 socket address" => std::n
 #[cfg(feature = "url")]
 impl_config_kind!(TypeKind::String; "String"; "An URL" => url::Url);
 
+impl_config_kind!(TypeKind::String; "String"; "A path" => std::path::PathBuf);
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
This patch implements `AsTypeDescription` for `PathBuf`