### PR TITLE
Toolchain: 1.65.0 -> 1.70.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0
+          - 1.70.0
           - stable
           - beta
           # - nightly
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.65.0
+        uses: dtolnay/rust-toolchain@1.70.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0
+          - 1.70.0
           - stable
           - beta
           # - nightly
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.65.0
+        uses: dtolnay/rust-toolchain@1.70.0
         with:
           components: clippy
       - uses: swatinem/rust-cache@v2
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.65.0
+        uses: dtolnay/rust-toolchain@1.70.0
       - uses: swatinem/rust-cache@v2
       - run: cargo install --locked cargo-outdated
       - run: cargo outdated --root-deps-only --color always

--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681265948,
-        "narHash": "sha256-wYS5dR1fRoU6VtoKScz1OUS/dmart7hfI0G71qkJcwc=",
+        "lastModified": 1687141659,
+        "narHash": "sha256-ckvEuxejYmFTyFF0u9CWV8h5u+ubuxA7vYrOw/GXRXg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b10a42fe6bb0b6d1b335c1f137419ebf754b2b59",
+        "rev": "86302751ef371597d48951983e1a2f04fe78d4ff",
         "type": "github"
       },
       "original": {

--- a/online_description_generator/src/main.rs
+++ b/online_description_generator/src/main.rs
@@ -41,7 +41,7 @@ fn start_app() {
 
         let location = document.location().unwrap();
 
-        let encoded_input = base64::engine::general_purpose::URL_SAFE.encode(&input.value());
+        let encoded_input = base64::engine::general_purpose::URL_SAFE.encode(input.value());
 
         location.set_hash(&encoded_input).unwrap();
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.70.0"
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]


### PR DESCRIPTION
Updates the rustc toolchain in use here.

To see whether this solves https://github.com/kbknapp/cargo-outdated/issues/355 for us.